### PR TITLE
NEW: API for external addons.

### DIFF
--- a/pages/background.js
+++ b/pages/background.js
@@ -24,6 +24,18 @@ const styleSwitcher = new StyleSwitcher(
 
 settings.onChange(styleSwitcher.refreshAllWindows.bind(styleSwitcher));
 
+
+//
+// Set up an onMessageEternal listener to provide an API for other
+// addons to query Border Color D's configuration.
+//
+// Currently, only a command to request a mapping of identity id's and
+// their color is implemented.
+//
+// Other addons can query it like so:
+// let ret = await browser.runtime.sendMessage("bordercolors-d@addonsdev.mozilla.org",
+//                                             {command: "getAllIdentitiesColors"});
+//
 browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
   if(request.command === "getAllIdentitiesColors") {
     const identities = new Identities();

--- a/pages/background.js
+++ b/pages/background.js
@@ -23,3 +23,35 @@ const styleSwitcher = new StyleSwitcher(
 );
 
 settings.onChange(styleSwitcher.refreshAllWindows.bind(styleSwitcher));
+
+browser.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+  if(request.command === "getAllIdentitiesColors") {
+    const identities = new Identities();
+    const settings = new Settings();
+
+    return new Promise((resolve, reject) => {
+      var identitiesIds = [];
+      var identitiesColors = [];
+
+      identities.forEach(identity => {
+        identitiesIds.push(identity.id);
+        identitiesColors.push(settings.getIdentityColor(identity.id));
+      }).then(x => {
+        Promise.all(identitiesColors).then(colors => {
+          let idColorsMap = [];
+          for (const [index, color] of colors.entries()) {
+            let id = identitiesIds[index];
+            idColorsMap[id] = color;
+          }
+
+          resolve({
+            command: "getAllIdentitiesColors",
+            data: idColorsMap
+          });
+        });
+      });
+    });
+
+    return false;
+  }
+});


### PR DESCRIPTION
The API allows external addons to request the identities<->colors configuration.

I'm the developer of the Thunderbird addon Identity Chooser and would like to integrate a bit with Border Colors D.

In particular, I'd like to query Border Colors which colors it has configured for all identities. In order to do so I implemented a simple API using [runtime.onMessageExternal](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessageExternal) which other addons can query using [runtime.sendMessage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendMessage).

It would be great if you could integrate this in Border Color and release it on ATN. Maybe we could coordinate the releases.
